### PR TITLE
Added N to secp256k1 __init__.py (needed for tests run in pyethereum)

### DIFF
--- a/py_ecc/secp256k1/__init__.py
+++ b/py_ecc/secp256k1/__init__.py
@@ -1,1 +1,1 @@
-from .secp256k1 import privtopub, ecdsa_raw_sign, ecdsa_raw_recover
+from .secp256k1 import privtopub, ecdsa_raw_sign, ecdsa_raw_recover, N


### PR DESCRIPTION
Something we stumbled upon when trying to run ``pyethereum`` tests for stack trace comparison with ``ethereumjs``.